### PR TITLE
Add CODEOWNERS for informasjonslaget

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @FINTLabs/informasjonslaget


### PR DESCRIPTION
Adds `.github/CODEOWNERS` with `* @FINTLabs/informasjonslaget` so informasjonslaget is set as code owner for repository files.